### PR TITLE
added pathType to ingress

### DIFF
--- a/charts/powerdns/templates/ingress.yaml
+++ b/charts/powerdns/templates/ingress.yaml
@@ -27,4 +27,5 @@ spec:
                 name: {{ $fullName }}-service
                 port: 
                   number: {{ $svcPort }}
+            pathType: ImplementationSpecific
 {{- end }}


### PR DESCRIPTION
pathType is mandatory -> selection between

- ImplementationSpecific (default): With this path type, matching is up to the controller implementing the IngressClass. Implementations can treat this as a separate pathType or treat it identically to the Prefix or Exact path types.
 - Exact: Matches the URL path exactly and with case sensitivity.
 - Prefix: Matches based on a URL path prefix split by /. Matching is case sensitive and done on a path element by element basis.